### PR TITLE
feat/msg.sender

### DIFF
--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -32,6 +32,7 @@ import (
 	"github.com/SigmaGmbH/evm-module/rpc/namespaces/ethereum/personal"
 	"github.com/SigmaGmbH/evm-module/rpc/namespaces/ethereum/txpool"
 	"github.com/SigmaGmbH/evm-module/rpc/namespaces/ethereum/web3"
+	"github.com/SigmaGmbH/evm-module/rpc/namespaces/utils"
 	ethermint "github.com/SigmaGmbH/evm-module/types"
 
 	rpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
@@ -52,6 +53,7 @@ const (
 	TxPoolNamespace   = "txpool"
 	DebugNamespace    = "debug"
 	MinerNamespace    = "miner"
+	UtilsNamespace    = "utils"
 
 	apiVersion = "1.0"
 )
@@ -167,6 +169,21 @@ func init() {
 					Version:   apiVersion,
 					Service:   miner.NewPrivateAPI(ctx, evmBackend),
 					Public:    false,
+				},
+			}
+		},
+		UtilsNamespace: func(_ *server.Context, 
+			_ client.Context, 
+			_ *rpcclient.WSClient, 
+			_ bool, 
+			_ ethermint.EVMTxIndexer,
+		) []rpc.API {
+			return []rpc.API{
+				{
+					Namespace: UtilsNamespace,
+					Version:   apiVersion,
+					Service:   utils.NewAPI(),
+					Public:    true,
 				},
 			}
 		},

--- a/rpc/backend/account_info.go
+++ b/rpc/backend/account_info.go
@@ -135,7 +135,23 @@ func (b *Backend) GetProof(address common.Address, storageKeys []string, blockNr
 
 // GetStorageAt returns the contract storage at the given address, block number, and key.
 func (b *Backend) GetStorageAt(address common.Address, key string, blockNrOrHash rpctypes.BlockNumberOrHash) (hexutil.Bytes, error) {
-	return nil, fmt.Errorf("This request was disabled!")
+	blockNum, err := b.BlockNumberFromTendermint(blockNrOrHash)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &evmtypes.QueryStorageRequest{
+		Address: address.String(),
+		Key:     key,
+	}
+
+	res, err := b.queryClient.Storage(rpctypes.ContextWithHeight(blockNum.Int64()), req)
+	if err != nil {
+		return nil, err
+	}
+
+	value := common.HexToHash(res.Value)
+	return value.Bytes(), nil
 }
 
 // GetBalance returns the provided account's balance up to the provided block number.

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -128,7 +128,7 @@ type EVMBackend interface {
 	SendRawTransaction(data hexutil.Bytes) (common.Hash, error)
 	SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.TransactionArgs, error)
 	EstimateGas(args evmtypes.TransactionArgs, blockNrOptional *rpctypes.BlockNumber) (hexutil.Uint64, error)
-	DoCall(args evmtypes.TransactionArgs, blockNr rpctypes.BlockNumber) (*evmtypes.MsgEthereumTxResponse, error)
+	DoCall(args evmtypes.CallArgs, blockNr rpctypes.BlockNumber) (*evmtypes.MsgEthereumTxResponse, error)
 	GasPrice() (*hexutil.Big, error)
 
 	// Filter API

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -342,7 +342,7 @@ func (b *Backend) EstimateGas(args evmtypes.TransactionArgs, blockNrOptional *rp
 // DoCall performs a simulated call operation through the evmtypes. It returns the
 // estimated gas used on the operation or an error if fails.
 func (b *Backend) DoCall(
-	args evmtypes.TransactionArgs, blockNr rpctypes.BlockNumber,
+	args evmtypes.CallArgs, blockNr rpctypes.BlockNumber,
 ) (*evmtypes.MsgEthereumTxResponse, error) {
 	bz, err := json.Marshal(&args)
 	if err != nil {

--- a/rpc/backend/call_tx_test.go
+++ b/rpc/backend/call_tx_test.go
@@ -379,7 +379,7 @@ func (suite *BackendTestSuite) TestDoCall() {
 	gasPrice := (*hexutil.Big)(big.NewInt(1))
 	toAddr := tests.GenerateAddress()
 	chainID := (*hexutil.Big)(suite.backend.chainID)
-	callArgs := evmtypes.TransactionArgs{
+	callArgs := evmtypes.CallArgs{
 		From:                 nil,
 		To:                   &toAddr,
 		Gas:                  nil,
@@ -399,7 +399,7 @@ func (suite *BackendTestSuite) TestDoCall() {
 		name         string
 		registerMock func()
 		blockNum     rpctypes.BlockNumber
-		callArgs     evmtypes.TransactionArgs
+		callArgs     evmtypes.CallArgs
 		expEthTx     *evmtypes.MsgEthereumTxResponse
 		expPass      bool
 	}{

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -84,7 +84,7 @@ type EthereumAPI interface {
 	//
 	// Allows developers to read data from the blockchain which includes executing
 	// smart contracts. However, no data is published to the Ethereum network.
-	Call(args evmtypes.TransactionArgs, blockNrOrHash rpctypes.BlockNumberOrHash, _ *rpctypes.StateOverride) (hexutil.Bytes, error)
+	Call(args evmtypes.CallArgs, blockNrOrHash rpctypes.BlockNumberOrHash, _ *rpctypes.StateOverride) (hexutil.Bytes, error)
 
 	// Chain Information
 	//
@@ -278,7 +278,7 @@ func (e *PublicAPI) GetProof(address common.Address,
 ///////////////////////////////////////////////////////////////////////////////
 
 // Call performs a raw contract call.
-func (e *PublicAPI) Call(args evmtypes.TransactionArgs,
+func (e *PublicAPI) Call(args evmtypes.CallArgs,
 	blockNrOrHash rpctypes.BlockNumberOrHash,
 	_ *rpctypes.StateOverride,
 ) (hexutil.Bytes, error) {

--- a/rpc/namespaces/utils/api.go
+++ b/rpc/namespaces/utils/api.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"github.com/ethereum/go-ethereum/common"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"swisstronik/app"
+)
+
+type API struct{}
+
+// NewAPI creates an instance of the utils API.
+func NewAPI() *API {
+	return &API{}
+}
+
+// ConvertAddress converts provided address from bech32 format to hex
+// and vice versa
+func (a *API) ConvertAddress(address string) (string, error) {
+	switch {
+	case common.IsHexAddress(address):
+		addrBytes := common.HexToAddress(address).Bytes()
+		convertedAddr := sdk.AccAddress(addrBytes)
+		return convertedAddr.String(), nil
+	case strings.HasPrefix(address, app.AccountAddressPrefix):
+		addrBytes, _ := sdk.AccAddressFromBech32(address)
+		convertedAddr := common.BytesToAddress(addrBytes)
+		return convertedAddr.String(), nil
+	default:
+		return "", fmt.Errorf("expected a valid hex or bech32 address")
+	}
+}

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -232,7 +232,7 @@ func (k Keeper) EthCall(c context.Context, req *types.EthCallRequest) (*types.Ms
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	var args types.TransactionArgs
+	var args types.CallArgs
 	err := json.Unmarshal(req.Args, &args)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/x/evm/types/call_args.go
+++ b/x/evm/types/call_args.go
@@ -1,0 +1,273 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	sdkmath "cosmossdk.io/math"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+// CallArgs represents the arguments to construct a new message call using JSON-RPC.
+// Main difference between `TransactionArgs` and `CallArgs` is optional `Signature` field.
+// It is used to recover original eth_call sender
+type CallArgs struct {
+	From                 *common.Address `json:"from"`
+	To                   *common.Address `json:"to"`
+	Gas                  *hexutil.Uint64 `json:"gas"`
+	GasPrice             *hexutil.Big    `json:"gasPrice"`
+	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
+	Value                *hexutil.Big    `json:"value"`
+	Nonce                *hexutil.Uint64 `json:"nonce"`
+
+	// We accept "data" and "input" for backwards-compatibility reasons.
+	// "input" is the newer name and should be preferred by clients.
+	// Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
+	Data  *hexutil.Bytes `json:"data"`
+	Input *hexutil.Bytes `json:"input"`
+
+	// Introduced by AccessListTxType transaction.
+	AccessList *ethtypes.AccessList `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big         `json:"chainId,omitempty"`
+
+	// Used to recover original eth_call sender. If empty, zero address will be recovered
+	V *hexutil.Big `json:"v,omitempty"`
+	R *hexutil.Big `json:"r,omitempty"`
+	S *hexutil.Big `json:"s,omitempty"`
+}
+
+// String return the struct in a string format
+func (args *CallArgs) String() string {
+	return fmt.Sprintf("TransactionArgs{From:%v, To:%v, Gas:%v, Nonce:%v, Data:%v, Input:%v, AccessList:%v}",
+		args.From,
+		args.To,
+		args.Gas,
+		args.Nonce,
+		args.Data,
+		args.Input,
+		args.AccessList)
+}
+
+// ToTransaction converts the arguments to an ethereum transaction.
+// This assumes that setTxDefaults has been called.
+func (args *CallArgs) ToTransaction() *MsgHandleTx {
+	var (
+		chainID, value, gasPrice, maxFeePerGas, maxPriorityFeePerGas sdkmath.Int
+		gas, nonce                                                   uint64
+		to		                                                     string
+		v, r, s														 []byte
+	)
+
+	// Set sender address or use zero address if none specified.
+	if args.ChainID != nil {
+		chainID = sdkmath.NewIntFromBigInt(args.ChainID.ToInt())
+	}
+
+	if args.Nonce != nil {
+		nonce = uint64(*args.Nonce)
+	}
+
+	if args.Gas != nil {
+		gas = uint64(*args.Gas)
+	}
+
+	if args.GasPrice != nil {
+		gasPrice = sdkmath.NewIntFromBigInt(args.GasPrice.ToInt())
+	}
+
+	if args.MaxFeePerGas != nil {
+		maxFeePerGas = sdkmath.NewIntFromBigInt(args.MaxFeePerGas.ToInt())
+	}
+
+	if args.MaxPriorityFeePerGas != nil {
+		maxPriorityFeePerGas = sdkmath.NewIntFromBigInt(args.MaxPriorityFeePerGas.ToInt())
+	}
+
+	if args.Value != nil {
+		value = sdkmath.NewIntFromBigInt(args.Value.ToInt())
+	}
+
+	if args.To != nil {
+		to = args.To.Hex()
+	}
+
+
+
+	var data TxData
+	switch {
+	case args.MaxFeePerGas != nil:
+		al := AccessList{}
+		if args.AccessList != nil {
+			al = NewAccessList(args.AccessList)
+		}
+
+		data = &DynamicFeeTx{
+			To:        to,
+			ChainID:   &chainID,
+			Nonce:     nonce,
+			GasLimit:  gas,
+			GasFeeCap: &maxFeePerGas,
+			GasTipCap: &maxPriorityFeePerGas,
+			Amount:    &value,
+			Data:      args.GetData(),
+			Accesses:  al,
+			V: 		   v,
+			R:         r,
+			S:         s,
+		}
+	case args.AccessList != nil:
+		data = &AccessListTx{
+			To:       to,
+			ChainID:  &chainID,
+			Nonce:    nonce,
+			GasLimit: gas,
+			GasPrice: &gasPrice,
+			Amount:   &value,
+			Data:     args.GetData(),
+			Accesses: NewAccessList(args.AccessList),
+			V: 		  v,
+			R:        r,
+			S:        s,
+		}
+	default:
+		data = &LegacyTx{
+			To:       to,
+			Nonce:    nonce,
+			GasLimit: gas,
+			GasPrice: &gasPrice,
+			Amount:   &value,
+			Data:     args.GetData(),
+			V: 		  v,
+			R:        r,
+			S:        s,
+		}
+	}
+
+	any, err := PackTxData(data)
+	if err != nil {
+		return nil
+	}
+
+	msg := MsgHandleTx{
+		Data: any,
+	}
+	msg.Hash = msg.AsTransaction().Hash().Hex()
+	
+	// If there is no provided signature or chain id, we use zeroed From address
+	if args.ChainID == nil || args.V == nil || args.R == nil || args.S == nil {
+		msg.From = common.Address{}.Hex()
+	} else {
+		// Otherwise recover `msg.sender` from provided signature 
+		signer := ethtypes.LatestSignerForChainID(args.ChainID.ToInt())
+		sender, err := signer.Sender(msg.AsTransaction())
+		if err != nil {
+			return nil
+		}
+		msg.From = sender.Hex()
+	}
+
+	return &msg
+}
+
+// ToMessage converts the arguments to the Message type used by the core evm.
+// This assumes that setTxDefaults has been called.
+func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (ethtypes.Message, error) {
+	// Reject invalid combinations of pre- and post-1559 fee styles
+	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
+		return ethtypes.Message{}, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+	}
+
+	// Recover from signature or use zero address if none specified.
+	addr := args.GetFrom()
+
+	// Set default gas & gas price if none were set
+	gas := globalGasCap
+	if gas == 0 {
+		gas = uint64(math.MaxUint64 / 2)
+	}
+	if args.Gas != nil {
+		gas = uint64(*args.Gas)
+	}
+	if globalGasCap != 0 && globalGasCap < gas {
+		gas = globalGasCap
+	}
+	var (
+		gasPrice  *big.Int
+		gasFeeCap *big.Int
+		gasTipCap *big.Int
+	)
+	if baseFee == nil {
+		// If there's no basefee, then it must be a non-1559 execution
+		gasPrice = new(big.Int)
+		if args.GasPrice != nil {
+			gasPrice = args.GasPrice.ToInt()
+		}
+		gasFeeCap, gasTipCap = gasPrice, gasPrice
+	} else {
+		// A basefee is provided, necessitating 1559-type execution
+		if args.GasPrice != nil {
+			// User specified the legacy gas field, convert to 1559 gas typing
+			gasPrice = args.GasPrice.ToInt()
+			gasFeeCap, gasTipCap = gasPrice, gasPrice
+		} else {
+			// User specified 1559 gas feilds (or none), use those
+			gasFeeCap = new(big.Int)
+			if args.MaxFeePerGas != nil {
+				gasFeeCap = args.MaxFeePerGas.ToInt()
+			}
+			gasTipCap = new(big.Int)
+			if args.MaxPriorityFeePerGas != nil {
+				gasTipCap = args.MaxPriorityFeePerGas.ToInt()
+			}
+			// Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
+			gasPrice = new(big.Int)
+			if gasFeeCap.BitLen() > 0 || gasTipCap.BitLen() > 0 {
+				gasPrice = math.BigMin(new(big.Int).Add(gasTipCap, baseFee), gasFeeCap)
+			}
+		}
+	}
+	value := new(big.Int)
+	if args.Value != nil {
+		value = args.Value.ToInt()
+	}
+	data := args.GetData()
+	var accessList ethtypes.AccessList
+	if args.AccessList != nil {
+		accessList = *args.AccessList
+	}
+
+	nonce := uint64(0)
+	if args.Nonce != nil {
+		nonce = uint64(*args.Nonce)
+	}
+
+	msg := ethtypes.NewMessage(addr, args.To, nonce, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, true)
+	return msg, nil
+}
+
+// GetFrom retrieves the transaction sender address.
+func (args *CallArgs) GetFrom() common.Address {
+	tx := args.ToTransaction()
+	if tx == nil {
+		return common.Address{}
+	}
+
+	return common.HexToAddress(tx.From)
+}
+
+// GetData retrieves the transaction calldata. Input field is preferred.
+func (args *CallArgs) GetData() []byte {
+	if args.Input != nil {
+		return *args.Input
+	}
+	if args.Data != nil {
+		return *args.Data
+	}
+	return nil
+}

--- a/x/evm/types/call_args.go
+++ b/x/evm/types/call_args.go
@@ -44,8 +44,7 @@ type CallArgs struct {
 
 // String return the struct in a string format
 func (args *CallArgs) String() string {
-	return fmt.Sprintf("TransactionArgs{From:%v, To:%v, Gas:%v, Nonce:%v, Data:%v, Input:%v, AccessList:%v}",
-		args.From,
+	return fmt.Sprintf("CallArgs{To:%v, Gas:%v, Nonce:%v, Data:%v, Input:%v, AccessList:%v}",
 		args.To,
 		args.Gas,
 		args.Nonce,

--- a/x/evm/types/call_args.go
+++ b/x/evm/types/call_args.go
@@ -59,8 +59,8 @@ func (args *CallArgs) ToTransaction() *MsgHandleTx {
 	var (
 		chainID, value, gasPrice, maxFeePerGas, maxPriorityFeePerGas sdkmath.Int
 		gas, nonce                                                   uint64
-		to		                                                     string
-		v, r, s														 []byte
+		to                                                           string
+		v, r, s                                                      []byte
 	)
 
 	// Set sender address or use zero address if none specified.
@@ -96,7 +96,16 @@ func (args *CallArgs) ToTransaction() *MsgHandleTx {
 		to = args.To.Hex()
 	}
 
-
+	// Extract signature values
+	if args.V != nil {
+		v = args.V.ToInt().Bytes()
+	}
+	if args.S != nil {
+		s = args.S.ToInt().Bytes()
+	}
+	if args.R != nil {
+		r = args.R.ToInt().Bytes()
+	}
 
 	var data TxData
 	switch {
@@ -116,7 +125,7 @@ func (args *CallArgs) ToTransaction() *MsgHandleTx {
 			Amount:    &value,
 			Data:      args.GetData(),
 			Accesses:  al,
-			V: 		   v,
+			V:         v,
 			R:         r,
 			S:         s,
 		}
@@ -130,7 +139,7 @@ func (args *CallArgs) ToTransaction() *MsgHandleTx {
 			Amount:   &value,
 			Data:     args.GetData(),
 			Accesses: NewAccessList(args.AccessList),
-			V: 		  v,
+			V:        v,
 			R:        r,
 			S:        s,
 		}
@@ -142,7 +151,7 @@ func (args *CallArgs) ToTransaction() *MsgHandleTx {
 			GasPrice: &gasPrice,
 			Amount:   &value,
 			Data:     args.GetData(),
-			V: 		  v,
+			V:        v,
 			R:        r,
 			S:        s,
 		}
@@ -157,12 +166,12 @@ func (args *CallArgs) ToTransaction() *MsgHandleTx {
 		Data: any,
 	}
 	msg.Hash = msg.AsTransaction().Hash().Hex()
-	
+
 	// If there is no provided signature or chain id, we use zeroed From address
-	if args.ChainID == nil || args.V == nil || args.R == nil || args.S == nil {
+	if args.ChainID == nil || v == nil || r == nil || s == nil {
 		msg.From = common.Address{}.Hex()
 	} else {
-		// Otherwise recover `msg.sender` from provided signature 
+		// Otherwise recover `msg.sender` from provided signature
 		signer := ethtypes.LatestSignerForChainID(args.ChainID.ToInt())
 		sender, err := signer.Sender(msg.AsTransaction())
 		if err != nil {

--- a/x/evm/types/call_args_test.go
+++ b/x/evm/types/call_args_test.go
@@ -251,7 +251,6 @@ func (suite *TxDataTestSuite) TestCallArgsGetFrom() {
 }
 
 func (suite *TxDataTestSuite) TestCallArgsGetFromSignature() {
-	// TODO: Restore test
 	chainId := big.NewInt(suite.hexBigInt.ToInt().Int64())
 	signer := ethtypes.LatestSignerForChainID(chainId)
 
@@ -263,8 +262,8 @@ func (suite *TxDataTestSuite) TestCallArgsGetFromSignature() {
 
 	args := CallArgs{
 		ChainID: &suite.hexBigInt,
-		To: &suite.addr,
-		Value: &suite.hexBigInt,
+		To:      &suite.addr,
+		Value:   &suite.hexBigInt,
 	}
 	argsAsTx := args.ToTransaction().AsTransaction()
 	signedTx, err := ethtypes.SignTx(argsAsTx, signer, ecdsaKey)
@@ -277,11 +276,11 @@ func (suite *TxDataTestSuite) TestCallArgsGetFromSignature() {
 
 	signedArgs := CallArgs{
 		ChainID: &suite.hexBigInt,
-		To: &suite.addr,
-		Value: &suite.hexBigInt,
-		V: &vBig,
-		R: &rBig,
-		S: &sBig,
+		To:      &suite.addr,
+		Value:   &suite.hexBigInt,
+		V:       &vBig,
+		R:       &rBig,
+		S:       &sBig,
 	}
 
 	restoredSender := signedArgs.GetFrom()

--- a/x/evm/types/call_args_test.go
+++ b/x/evm/types/call_args_test.go
@@ -1,0 +1,287 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	//"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+func (suite *TxDataTestSuite) TestCallArgsString() {
+	testCases := []struct {
+		name           string
+		callArgs       CallArgs
+		expectedString string
+	}{
+		{
+			"empty tx args",
+			CallArgs{},
+			"CallArgs{To:<nil>, Gas:<nil>, Nonce:<nil>, Data:<nil>, Input:<nil>, AccessList:<nil>}",
+		},
+		{
+			"call args with fields",
+			CallArgs{
+				From:       &suite.addr,
+				To:         &suite.addr,
+				Gas:        &suite.hexUint64,
+				Nonce:      &suite.hexUint64,
+				Input:      &suite.hexInputBytes,
+				Data:       &suite.hexDataBytes,
+				AccessList: &ethtypes.AccessList{},
+			},
+			fmt.Sprintf("CallArgs{To:%v, Gas:%v, Nonce:%v, Data:%v, Input:%v, AccessList:%v}",
+				&suite.addr,
+				&suite.hexUint64,
+				&suite.hexUint64,
+				&suite.hexDataBytes,
+				&suite.hexInputBytes,
+				&ethtypes.AccessList{}),
+		},
+	}
+	for _, tc := range testCases {
+		outputString := tc.callArgs.String()
+		suite.Require().Equal(outputString, tc.expectedString)
+	}
+}
+
+func (suite *TxDataTestSuite) TestConvertCallArgsEthTx() {
+	testCases := []struct {
+		name     string
+		callArgs CallArgs
+	}{
+		{
+			"empty tx args",
+			CallArgs{},
+		},
+		{
+			"no nil args",
+			CallArgs{
+				From:                 &suite.addr,
+				To:                   &suite.addr,
+				Gas:                  &suite.hexUint64,
+				GasPrice:             &suite.hexBigInt,
+				MaxFeePerGas:         &suite.hexBigInt,
+				MaxPriorityFeePerGas: &suite.hexBigInt,
+				Value:                &suite.hexBigInt,
+				Nonce:                &suite.hexUint64,
+				Data:                 &suite.hexDataBytes,
+				Input:                &suite.hexInputBytes,
+				AccessList:           &ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}},
+				ChainID:              &suite.hexBigInt,
+			},
+		},
+		{
+			"max fee per gas nil, but access list not nil",
+			CallArgs{
+				From:                 &suite.addr,
+				To:                   &suite.addr,
+				Gas:                  &suite.hexUint64,
+				GasPrice:             &suite.hexBigInt,
+				MaxFeePerGas:         nil,
+				MaxPriorityFeePerGas: &suite.hexBigInt,
+				Value:                &suite.hexBigInt,
+				Nonce:                &suite.hexUint64,
+				Data:                 &suite.hexDataBytes,
+				Input:                &suite.hexInputBytes,
+				AccessList:           &ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}},
+				ChainID:              &suite.hexBigInt,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		res := tc.callArgs.ToTransaction()
+		suite.Require().NotNil(res)
+	}
+}
+
+func (suite *TxDataTestSuite) TestCallArgsToEVMMessage() {
+	testCases := []struct {
+		name         string
+		callArgs     CallArgs
+		globalGasCap uint64
+		baseFee      *big.Int
+		expError     bool
+	}{
+		{
+			"empty tx args",
+			CallArgs{},
+			uint64(0),
+			nil,
+			false,
+		},
+		{
+			"specify gasPrice and (maxFeePerGas or maxPriorityFeePerGas)",
+			CallArgs{
+				From:                 &suite.addr,
+				To:                   &suite.addr,
+				Gas:                  &suite.hexUint64,
+				GasPrice:             &suite.hexBigInt,
+				MaxFeePerGas:         &suite.hexBigInt,
+				MaxPriorityFeePerGas: &suite.hexBigInt,
+				Value:                &suite.hexBigInt,
+				Nonce:                &suite.hexUint64,
+				Data:                 &suite.hexDataBytes,
+				Input:                &suite.hexInputBytes,
+				AccessList:           &ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}},
+				ChainID:              &suite.hexBigInt,
+			},
+			uint64(0),
+			nil,
+			true,
+		},
+		{
+			"non-1559 execution, zero gas cap",
+			CallArgs{
+				From:                 &suite.addr,
+				To:                   &suite.addr,
+				Gas:                  &suite.hexUint64,
+				GasPrice:             &suite.hexBigInt,
+				MaxFeePerGas:         nil,
+				MaxPriorityFeePerGas: nil,
+				Value:                &suite.hexBigInt,
+				Nonce:                &suite.hexUint64,
+				Data:                 &suite.hexDataBytes,
+				Input:                &suite.hexInputBytes,
+				AccessList:           &ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}},
+				ChainID:              &suite.hexBigInt,
+			},
+			uint64(0),
+			nil,
+			false,
+		},
+		{
+			"non-1559 execution, nonzero gas cap",
+			CallArgs{
+				From:                 &suite.addr,
+				To:                   &suite.addr,
+				Gas:                  &suite.hexUint64,
+				GasPrice:             &suite.hexBigInt,
+				MaxFeePerGas:         nil,
+				MaxPriorityFeePerGas: nil,
+				Value:                &suite.hexBigInt,
+				Nonce:                &suite.hexUint64,
+				Data:                 &suite.hexDataBytes,
+				Input:                &suite.hexInputBytes,
+				AccessList:           &ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}},
+				ChainID:              &suite.hexBigInt,
+			},
+			uint64(1),
+			nil,
+			false,
+		},
+		{
+			"1559-type execution, nil gas price",
+			CallArgs{
+				From:                 &suite.addr,
+				To:                   &suite.addr,
+				Gas:                  &suite.hexUint64,
+				GasPrice:             nil,
+				MaxFeePerGas:         &suite.hexBigInt,
+				MaxPriorityFeePerGas: &suite.hexBigInt,
+				Value:                &suite.hexBigInt,
+				Nonce:                &suite.hexUint64,
+				Data:                 &suite.hexDataBytes,
+				Input:                &suite.hexInputBytes,
+				AccessList:           &ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}},
+				ChainID:              &suite.hexBigInt,
+			},
+			uint64(1),
+			suite.bigInt,
+			false,
+		},
+		{
+			"1559-type execution, non-nil gas price",
+			CallArgs{
+				From:                 &suite.addr,
+				To:                   &suite.addr,
+				Gas:                  &suite.hexUint64,
+				GasPrice:             &suite.hexBigInt,
+				MaxFeePerGas:         nil,
+				MaxPriorityFeePerGas: nil,
+				Value:                &suite.hexBigInt,
+				Nonce:                &suite.hexUint64,
+				Data:                 &suite.hexDataBytes,
+				Input:                &suite.hexInputBytes,
+				AccessList:           &ethtypes.AccessList{{Address: suite.addr, StorageKeys: []common.Hash{{0}}}},
+				ChainID:              &suite.hexBigInt,
+			},
+			uint64(1),
+			suite.bigInt,
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		res, err := tc.callArgs.ToMessage(tc.globalGasCap, tc.baseFee)
+
+		if tc.expError {
+			suite.Require().NotNil(err)
+		} else {
+			suite.Require().Nil(err)
+			suite.Require().NotNil(res)
+		}
+	}
+}
+
+func (suite *TxDataTestSuite) TestCallArgsGetFrom() {
+	testCases := []struct {
+		name       string
+		callArgs   CallArgs
+		expAddress common.Address
+	}{
+		{
+			"empty signature field",
+			CallArgs{},
+			common.Address{},
+		},
+		{
+			"non-empty from field, but empty signature",
+			CallArgs{
+				From: &suite.addr,
+			},
+			common.Address{},
+		},
+	}
+	for _, tc := range testCases {
+		retrievedAddress := tc.callArgs.GetFrom()
+		suite.Require().Equal(retrievedAddress, tc.expAddress)
+	}
+}
+
+func (suite *TxDataTestSuite) TestCallArgsGetData() {
+	testCases := []struct {
+		name           string
+		callArgs       CallArgs
+		expectedOutput []byte
+	}{
+		{
+			"empty input and data fields",
+			CallArgs{
+				Data:  nil,
+				Input: nil,
+			},
+			nil,
+		},
+		{
+			"empty input field, non-empty data field",
+			CallArgs{
+				Data:  &suite.hexDataBytes,
+				Input: nil,
+			},
+			[]byte("data"),
+		},
+		{
+			"non-empty input and data fields",
+			CallArgs{
+				Data:  &suite.hexDataBytes,
+				Input: &suite.hexInputBytes,
+			},
+			[]byte("input"),
+		},
+	}
+	for _, tc := range testCases {
+		retrievedData := tc.callArgs.GetData()
+		suite.Require().Equal(retrievedData, tc.expectedOutput)
+	}
+}


### PR DESCRIPTION
- Add possibility to provide signature within `eth_call`
- Restore msg.sender in `eth_call` from signature or use `0x000..0000` address
- Add `utils` JSON-RPC namespace with `utils_convertAddress` method which can be used to convert bech32 addresses to hex and vice versa  
- Enable `eth_getStorageAt` method